### PR TITLE
fix: Cannot find module '../../../dist/src' for the examples

### DIFF
--- a/examples/react/server/server.ts
+++ b/examples/react/server/server.ts
@@ -5,7 +5,7 @@ import ReactRefreshTypeScript from 'react-refresh-typescript';
 import webpack from 'webpack';
 import {
   fastifyWebpackHot,
-} from '../../../dist/src';
+} from '../../../src';
 
 const main = async () => {
   const app = fastify();

--- a/examples/webpack/server/server.ts
+++ b/examples/webpack/server/server.ts
@@ -3,7 +3,7 @@ import fastify from 'fastify';
 import webpack from 'webpack';
 import {
   fastifyWebpackHot,
-} from '../../../dist/src';
+} from '../../../src';
 
 const main = async () => {
   const app = fastify();


### PR DESCRIPTION
This PR fixes the error in the react and webpack examples after running the "npm start" command